### PR TITLE
update dependencies and replace deprecated functions

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,8 +10,8 @@ runtime = "deno"
 typescript_declarations = true
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-gleam_javascript = ">= 0.12.0 and < 1.0.0"
+gleam_stdlib = ">= 0.59.0 and < 1.0.0"
+gleam_javascript = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_javascript", version = "0.12.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "6EB652538B31E852FE0A8307A8B6314DEB34930944B6DDC41CCC31CA344DA35D" },
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
+  { name = "gleam_javascript", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "EF6C77A506F026C6FB37941889477CD5E4234FCD4337FF0E9384E297CB8F97EB" },
+  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
-gleam_javascript = { version = ">= 0.12.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_javascript = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.59.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/dinostore/key.gleam
+++ b/src/dinostore/key.gleam
@@ -1,6 +1,6 @@
 import dinostore/ulid
 import gleam/dynamic
-import gleam/result
+import gleam/dynamic/decode
 
 pub type KeyPart {
   StringPart(value: String)
@@ -12,7 +12,7 @@ pub type KeyPart {
 
 /// A key is simply a list of `KeyPart`s.
 pub type Key =
-  List(KeyPart)
+List(KeyPart)
 
 /// Helper function to create a `StringPart`.
 pub fn s(s: String) -> KeyPart {
@@ -64,12 +64,16 @@ pub fn unwrap(key: Key) -> JsKey
 /// [secondary indexes](https://docs.deno.com/deploy/kv/manual/#improve-querying-with-secondary-indexes)
 /// where a primary key is stored as a secondary index's value.
 ///
-pub fn decode(x: dynamic.Dynamic) {
-  dynamic.list(
-    of: dynamic.any(of: [
-      fn(x) { result.map(dynamic.string(x), StringPart) },
-      fn(x) { result.map(dynamic.float(x), NumberPart) },
-      fn(x) { result.map(dynamic.bool(x), BoolPart) },
-    ]),
-  )(x)
+pub fn decode(
+x: dynamic.Dynamic,
+) -> Result(List(KeyPart), List(decode.DecodeError)) {
+  decode.run(
+  x,
+  decode.list(
+  of: decode.one_of(decode.string |> decode.map(StringPart), or: [
+  decode.float |> decode.map(NumberPart),
+  decode.bool |> decode.map(BoolPart),
+  ]),
+  ),
+  )
 }


### PR DESCRIPTION
- Update `gleam_javascript` to `>= 1.0.0 and < 2.0.0`
- Update `gleam_stdlib` to `>= 0.59.0 and < 1.0.0`
- Replace deprecated decoders from `gleam/dynamic` with newer `gleam/dynamic/decode`
- Replace deprecated `io.debug` call in tests with regular `io.print` and `io.println`